### PR TITLE
Composer takes an object `currentUser`

### DIFF
--- a/packages/core/src/models/model.ts
+++ b/packages/core/src/models/model.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export * from './configuration/index'
+export * from './user/index'

--- a/packages/core/src/models/user/User.ts
+++ b/packages/core/src/models/user/User.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Mia srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {FromSchema} from 'json-schema-to-ts'
+
+export const userSchema = {
+  type: 'object',
+  properties: {
+    avatar: {
+      type: 'string',
+    },
+    email: {
+      type: 'string',
+    },
+    groups: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+    },
+    name: {
+      type: 'string',
+    },
+    nickname: {
+      type: 'string',
+    },
+  },
+  required: ['email', 'groups', 'name'],
+} as const
+
+export type User = FromSchema<typeof userSchema>

--- a/packages/core/src/models/user/index.ts
+++ b/packages/core/src/models/user/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2021 Mia srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './User'

--- a/packages/fe-container/src/components/Composer.tsx
+++ b/packages/fe-container/src/components/Composer.tsx
@@ -5,14 +5,31 @@ import {LoadingAnimation} from '@mia-platform/microlc-ui-components'
 import viewEngine from '../composer/ViewEngine'
 import useConfiguration from '../hooks/useConfiguration'
 
+const requiredStringShape = PropTypes.shape({
+  type: PropTypes.string.isRequired
+})
+
+const currentUserShape = PropTypes.shape({
+  properties: PropTypes.shape({
+    avatar: requiredStringShape.isRequired,
+    email: requiredStringShape.isRequired,
+    groups: PropTypes.shape({
+      items: requiredStringShape.isRequired,
+      type: PropTypes.string.isRequired
+    }).isRequired,
+    name: requiredStringShape.isRequired,
+    nickname: requiredStringShape.isRequired
+  }).isRequired,
+  required: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  type: PropTypes.string.isRequired
+}).isRequired
+
 const propTypes = {
   configurationName: PropTypes.string.isRequired,
-  currentUser: PropTypes.object
+  currentUser: currentUserShape
 }
 
-type ComposerProps = PropTypes.InferProps<typeof propTypes> & {
-  currentUser?: object
-}
+type ComposerProps = PropTypes.InferProps<typeof propTypes>
 
 const Composer: React.FC<ComposerProps> = ({configurationName, currentUser}) => {
   const configuration = useConfiguration(configurationName)

--- a/packages/fe-container/src/components/Composer.tsx
+++ b/packages/fe-container/src/components/Composer.tsx
@@ -5,24 +5,13 @@ import {LoadingAnimation} from '@mia-platform/microlc-ui-components'
 import viewEngine from '../composer/ViewEngine'
 import useConfiguration from '../hooks/useConfiguration'
 
-const requiredStringShape = PropTypes.shape({
-  type: PropTypes.string.isRequired
-})
-
 const currentUserShape = PropTypes.shape({
-  properties: PropTypes.shape({
-    avatar: requiredStringShape.isRequired,
-    email: requiredStringShape.isRequired,
-    groups: PropTypes.shape({
-      items: requiredStringShape.isRequired,
-      type: PropTypes.string.isRequired
-    }).isRequired,
-    name: requiredStringShape.isRequired,
-    nickname: requiredStringShape.isRequired
-  }).isRequired,
-  required: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
-  type: PropTypes.string.isRequired
-}).isRequired
+  avatar: PropTypes.string,
+  email: PropTypes.string.isRequired,
+  groups: PropTypes.arrayOf(PropTypes.string.isRequired),
+  name: PropTypes.string.isRequired,
+  nickname: PropTypes.string
+})
 
 const propTypes = {
   configurationName: PropTypes.string.isRequired,
@@ -37,6 +26,7 @@ const Composer: React.FC<ComposerProps> = ({configurationName, currentUser}) => 
 
   useEffect(() => {
     if (configuration) {
+      // @ts-ignore
       viewEngine([configuration], currentUser, rootComponent.current.parentElement)
     }
   }, [configuration, currentUser])

--- a/packages/fe-container/src/components/Composer.tsx
+++ b/packages/fe-container/src/components/Composer.tsx
@@ -6,20 +6,23 @@ import viewEngine from '../composer/ViewEngine'
 import useConfiguration from '../hooks/useConfiguration'
 
 const propTypes = {
-  configurationName: PropTypes.string.isRequired
+  configurationName: PropTypes.string.isRequired,
+  currentUser: PropTypes.object
 }
 
-type ComposerProps = PropTypes.InferProps<typeof propTypes>
+type ComposerProps = PropTypes.InferProps<typeof propTypes> & {
+  currentUser?: object
+}
 
-const Composer: React.FC<ComposerProps> = ({configurationName}) => {
+const Composer: React.FC<ComposerProps> = ({configurationName, currentUser}) => {
   const configuration = useConfiguration(configurationName)
   const rootComponent = useRef<any>()
 
   useEffect(() => {
     if (configuration) {
-      viewEngine([configuration], rootComponent.current.parentElement)
+      viewEngine([configuration], currentUser, rootComponent.current.parentElement)
     }
-  }, [configuration])
+  }, [configuration, currentUser])
 
   return (
     configuration ? <div data-testid={'sibling-div'} ref={rootComponent}/> : <LoadingAnimation/>

--- a/packages/fe-container/src/composer/NodeCreator.ts
+++ b/packages/fe-container/src/composer/NodeCreator.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Configuration} from '@mia-platform/core'
+import {Configuration, User} from '@mia-platform/core'
 import {ReplaySubject, Subject} from 'rxjs'
 
 const rowStyle = 'display: flex; flex-direction: column'
@@ -54,7 +54,7 @@ const retrieveEventBus = (configuration: Configuration): Subject<any> | undefine
   return eventBus
 }
 
-const createEnrichedElement = (configuration: Configuration, currentUser: object, defaultEventBus: Subject<any>) => {
+const createEnrichedElement = (configuration: Configuration, currentUser: Partial<User>, defaultEventBus: Subject<any>) => {
   // @ts-ignore
   const element = document.createElement(configuration.tag)
   const eventBus = retrieveEventBus(configuration) || defaultEventBus
@@ -63,7 +63,7 @@ const createEnrichedElement = (configuration: Configuration, currentUser: object
   return element
 }
 
-const createElement = (configuration: Configuration, currentUser: object, eventBus: Subject<any>) => {
+const createElement = (configuration: Configuration, currentUser: Partial<User>, eventBus: Subject<any>) => {
   importScript(configuration)
   return createEnrichedElement(configuration, currentUser, eventBus)
 }
@@ -74,7 +74,7 @@ const strategies = {
   element: createElement
 }
 
-const createNode = (configuration: Configuration, currentUser: object, eventBus: Subject<any>) => {
+const createNode = (configuration: Configuration, currentUser: Partial<User>, eventBus: Subject<any>) => {
   const strategy = strategies[configuration.type]
   return strategy(configuration, currentUser, eventBus)
 }

--- a/packages/fe-container/src/composer/NodeCreator.ts
+++ b/packages/fe-container/src/composer/NodeCreator.ts
@@ -54,18 +54,18 @@ const retrieveEventBus = (configuration: Configuration): Subject<any> | undefine
   return eventBus
 }
 
-const createEnrichedElement = (configuration: Configuration, defaultEventBus: Subject<any>) => {
+const createEnrichedElement = (configuration: Configuration, currentUser: object, defaultEventBus: Subject<any>) => {
   // @ts-ignore
   const element = document.createElement(configuration.tag)
   const eventBus = retrieveEventBus(configuration) || defaultEventBus
-  const additionalProps = {eventBus, style: configuration.style || ''}
+  const additionalProps = {eventBus, style: configuration.style || '', currentUser}
   Object.entries({...configuration.config || {}, ...additionalProps}).forEach(enrichElementProps(element))
   return element
 }
 
-const createElement = (configuration: Configuration, eventBus: Subject<any>) => {
+const createElement = (configuration: Configuration, currentUser: object, eventBus: Subject<any>) => {
   importScript(configuration)
-  return createEnrichedElement(configuration, eventBus)
+  return createEnrichedElement(configuration, currentUser, eventBus)
 }
 
 const strategies = {
@@ -74,9 +74,9 @@ const strategies = {
   element: createElement
 }
 
-const createNode = (configuration: Configuration, eventBus: Subject<any>) => {
+const createNode = (configuration: Configuration, currentUser: object, eventBus: Subject<any>) => {
   const strategy = strategies[configuration.type]
-  return strategy(configuration, eventBus)
+  return strategy(configuration, currentUser, eventBus)
 }
 
 export default createNode

--- a/packages/fe-container/src/composer/ViewEngine.ts
+++ b/packages/fe-container/src/composer/ViewEngine.ts
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Configuration} from '@mia-platform/core'
+import {Configuration, User} from '@mia-platform/core'
 import {ReplaySubject, Subject} from 'rxjs'
 
 import createNode from './NodeCreator'
 
 const viewEngine = (configurations: Configuration[],
-  currentUser: object = {},
+  currentUser: Partial<User> = {},
   root: HTMLElement = document.createElement('div'),
   eventBus: Subject<any> = new ReplaySubject<any>()): HTMLElement => {
   configurations.forEach(configuration => {

--- a/packages/fe-container/src/composer/ViewEngine.ts
+++ b/packages/fe-container/src/composer/ViewEngine.ts
@@ -19,11 +19,12 @@ import {ReplaySubject, Subject} from 'rxjs'
 import createNode from './NodeCreator'
 
 const viewEngine = (configurations: Configuration[],
+  currentUser: object = {},
   root: HTMLElement = document.createElement('div'),
   eventBus: Subject<any> = new ReplaySubject<any>()): HTMLElement => {
   configurations.forEach(configuration => {
-    const createdNode = createNode(configuration, eventBus)
-    viewEngine(configuration.content || [], createdNode, eventBus)
+    const createdNode = createNode(configuration, currentUser, eventBus)
+    viewEngine(configuration.content || [], currentUser, createdNode, eventBus)
     root.appendChild(createdNode)
   })
   return root

--- a/packages/fe-container/src/composer/__tests__/ViewEngine.test.ts
+++ b/packages/fe-container/src/composer/__tests__/ViewEngine.test.ts
@@ -201,3 +201,32 @@ describe('ViewEngine tests', () => {
     expect(button.eventBus).toBe(button2.eventBus)
   })
 })
+
+describe('ViewEngine tests supporting `currentUser` prop', () => {
+  it('creates an element with no `currentUser` prop', () => {
+    const element: 'element' = 'element'
+    const rowConfig = {
+      type: element,
+      tag: 'div'
+    }
+    const viewBuilt = viewEngine([rowConfig])
+    const div = viewBuilt.getElementsByTagName('div')[0]
+    // @ts-ignore
+    expect(div.currentUser).toMatchObject({})
+  })
+  it('creates an element with a `currentUser` prop', () => {
+    const currentUser = {
+      name: 'user'
+    }
+
+    const element: 'element' = 'element'
+    const rowConfig = {
+      type: element,
+      tag: 'div'
+    }
+    const viewBuilt = viewEngine([rowConfig], currentUser)
+    const div = viewBuilt.getElementsByTagName('div')[0]
+    // @ts-ignore
+    expect(div.currentUser).toMatchObject(currentUser)
+  })
+})

--- a/packages/fe-container/src/index.tsx
+++ b/packages/fe-container/src/index.tsx
@@ -28,7 +28,13 @@ function retrieveContainer (props: any) {
 }
 
 function render (props: any) {
-  ReactDOM.render(<Composer configurationName={props.configurationName}/>, retrieveContainer(props))
+  ReactDOM.render(
+    <Composer
+      configurationName={props.configurationName}
+      currentUser={props.currentUser}
+    />,
+    retrieveContainer(props)
+  )
 }
 
 export async function mount (props: any) {


### PR DESCRIPTION
In order to receive & re-inject the authenticated user from `microlc`, `Composer` element handles a `currentUser` prop. This prop is defaulted as empty object. Two tests verify compliance with the given specification